### PR TITLE
Add 'm' option to format timestamp similar to 'd' but only includes millis

### DIFF
--- a/src/multilog.c
+++ b/src/multilog.c
@@ -496,12 +496,15 @@ void doit(char **script)
   int flagselected;
   int flagtimestamp;
   int flagdatetime;
-
+  int flagdatetimemillis;
+  
   flagtimestamp = 0;
   flagdatetime  = 0;
+  flagdatetimemillis  = 0;
   if (script[0]) {
     if (script[0][0] == 't') flagtimestamp = 1;
     else if (script[0][0] == 'd') flagdatetime = 1;
+    else if (script[0][0] == 'm') flagdatetimemillis = 1;
   }
 
   for (i = 0;i <= 1000;++i) line[i] = '\n';
@@ -528,6 +531,11 @@ void doit(char **script)
           readable_datetime(line);
           line[29] = ' ';
           linelen = 30;
+        }
+        else if (flagdatetimemillis) {
+          readable_datetimemillis(line);
+          line[23] = ' ';
+          linelen = 24;
         }
       }
       if (ch == '\n') break;

--- a/src/timestamp.c
+++ b/src/timestamp.c
@@ -34,3 +34,16 @@ void readable_datetime(char s[DATETIME])
   sprintf(nsec_buf, ".%09ld", tv.tv_nsec);
   strcat(s, nsec_buf);
 }
+
+void readable_datetimemillis(char *s)
+{
+  char msec_buf[5];
+  long ms;
+  clock_gettime(CLOCK_REALTIME, &tv);
+  tm_info = localtime(&tv.tv_sec);
+  strftime(s, DATETIME, "%F %T", tm_info);
+  ms = tv.tv_nsec / 1000000;
+  if (ms > 1000) ms = 0;
+  snprintf(msec_buf, sizeof(msec_buf), ".%03ld", ms);
+  strcat(s, msec_buf);
+}

--- a/src/timestamp.h
+++ b/src/timestamp.h
@@ -6,5 +6,6 @@
 
 extern void timestamp(char *);
 extern void readable_datetime(char *);
+extern void readable_datetimemillis(char *);
 
 #endif


### PR DESCRIPTION
Adds option for millis when nanosecond precision is not required.
